### PR TITLE
Update GoLand 2017.3.1

### DIFF
--- a/programming/goland/actions.py
+++ b/programming/goland/actions.py
@@ -7,6 +7,6 @@ WorkDir = "."
 Version =  get.srcVERSION()
 
 def install():
-    shutil.rmtree("GoLand-%s/jre64" % Version)
-    pisitools.insinto("/opt/goland", "GoLand-%s/*" % Version)
+    shutil.rmtree("GoLand-2017.3/jre64")
+    pisitools.insinto("/opt/goland", "GoLand-*/*")
     pisitools.dosym("/opt/goland/bin/goland.sh", "/usr/bin/goland")

--- a/programming/goland/pspec.xml
+++ b/programming/goland/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Goland - an IDE for the Go Language</Summary>
         <Description xml:lang="en">Goland - an IDE for the Go Language</Description>
-        <Archive type="targz" sha1sum="e175e0a0164d31ddaddb00586dd9d038f6cba6ac">https://download.jetbrains.com/go/goland-2017.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="85bb875cb11210a1cb2bc087bfc72a6cb7b1b06e">https://download.jetbrains.com/go/goland-2017.3.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>goland</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="2">
+          <Date>2018-01-17</Date>
+          <Version>2017.3.1</Version>
+          <Comment>Update GoLand 2017.3.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
         <Update release="1">
             <Date>2017-12-05</Date>
             <Version>2017.3</Version>


### PR DESCRIPTION
Update GoLand to version 2017.3.1 from January 8, 2018.

Tests:
Build, Install, Execution

Signed-off-by: ahahn94 <ahahn94@outlook.com>