### PR TITLE
Add Kotlin/Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/ahahn94/my-3rd-p
 sudo eopkg it goldencheetah*.eopkg;sudo rm goldencheetah*.eopkg
 ```
 
+## Kotlin/Native  
+```
+sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/ahahn94/my-3rd-party/master/programming/kotlin-native/pspec.xml
+sudo eopkg it kotlin-native*.eopkg;sudo rm kotlin-native*.eopkg
+```
+
 ## Modelio  
 ```
 sudo eopkg bi --ignore-safety https://raw.githubusercontent.com/ahahn94/my-3rd-party/master/programming/modelio/pspec.xml

--- a/programming/kotlin-native/actions.py
+++ b/programming/kotlin-native/actions.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+# Created For Solus Operating System
+
+from pisi.actionsapi import get, pisitools, shelltools
+import shutil
+
+NoStrip = ["/usr"]
+IgnoreAutodep = True
+
+Version = get.srcVERSION()
+
+def setup():
+    shelltools.system("pwd")
+    shelltools.system("tar xzvf kotlin-native-linux-%s.tar.gz" % Version)
+
+def install():
+    shutil.rmtree("kotlin-native-linux-%s/samples" % Version)
+    pisitools.insinto("/opt/kotlin-native", "kotlin-native-linux-%s/*" % Version)
+    pisitools.dosym("/opt/kotlin-native/bin/cinterop", "/usr/bin/cinterop")
+    pisitools.dosym("/opt/kotlin-native/bin/jsinterop", "/usr/bin/jsinterop")
+    pisitools.dosym("/opt/kotlin-native/bin/klib", "/usr/bin/klib")
+    pisitools.dosym("/opt/kotlin-native/bin/konanc", "/usr/bin/konanc")
+    pisitools.dosym("/opt/kotlin-native/bin/kotlinc-native", "/usr/bin/kotlinc-native")
+    pisitools.dosym("/opt/kotlin-native/bin/run_konan", "/usr/bin/run_konan")

--- a/programming/kotlin-native/pspec.xml
+++ b/programming/kotlin-native/pspec.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://solus-project.com/standard/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>kotlin-native</Name>
+        <Packager>
+            <Name>ahahn94</Name>
+            <Email>ahahn94</Email>
+        </Packager>
+        <Summary>Kotlin/Native infrastructure.</Summary>
+        <Description>Kotlin/Native infrastructure.</Description>
+        <License>Apache 2.0, (c) JetBrains</License>
+        <Archive sha1sum="d30cdcbd76eee5e53ff4551cf51104729143cf80" type="binary">https://github.com/JetBrains/kotlin-native/releases/download/v0.6.2/kotlin-native-linux-0.6.2.tar.gz</Archive>
+
+        <BuildDependencies>
+            <Dependency>binutils</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <Name>kotlin-native</Name>
+        <Files>
+            <Path fileType="data">/opt/kotlin-native</Path>
+            <Path fileType="data">/usr/bin</Path>
+        </Files>
+    </Package>
+    <History>
+        <Update release="1">
+            <Date>2018-04-12</Date>
+            <Version>0.6.2</Version>
+            <Comment>Add kotlin-native to repositories</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
Add package for Kotlin/Native.
This does not include Kotlin, as it is provided via the repo as a separate package.

Note: Kotlin/Native is still prerelease.

Signed-off-by: ahahn94 <ahahn94@outlook.com>